### PR TITLE
Settings edit page referenced missing notify_email field & email refactoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     taps (0.3.15)
       json (~> 1.4.6)
       rack (>= 1.0.1)
-      rest-client (>= 1.4.0, < 1.7.0)
+      rest-client (< 1.7.0, >= 1.4.0)
       sequel (~> 3.17.0)
       sinatra (~> 1.0.0)
       sqlite3-ruby (~> 1.2)

--- a/app/views/admin/configurations/edit.html.erb
+++ b/app/views/admin/configurations/edit.html.erb
@@ -47,12 +47,6 @@
 			<div class="clear"></div>
 	  </div>
 	
-	  <div class="field">
-	    <div class="label"><%= f.label :notify_email %></div>
-	    <div class="input"><%= f.text_field :notify_email, :size => 60 %></div>
-			<div class="clear"></div>
-	  </div>
-	
 	  <div class="actions">
 	    <%=link_to 'Back to Home', root_path%>
 			<%= f.submit %>

--- a/app/views/notifier/sync_email.html.erb
+++ b/app/views/notifier/sync_email.html.erb
@@ -1,9 +1,9 @@
 Import Summary:<br/>
 Time: <%= Time.now %><br/>
 Total surveys imported: <%= @import_histories.length %><br/>
-Success: <%= @import_histories.select{|import_history| import_history.status == 'Success'}.length %><br/>
-Incomplete: <%= @import_histories.select{|import_history| import_history.status == 'Incomplete'}.length %><br/>
-Failed: <%= @import_histories.select{|import_history| import_history.status == 'Failed'}.length %><br/>
+Success: <%= @import_histories.count { |import_history| import_history.status == 'Success'} %><br/>
+Incomplete: <%= @import_histories.count { |import_history| import_history.status == 'Incomplete'} %><br/>
+Failed: <%= @import_histories.count { |import_history| import_history.status == 'Failed'} %><br/>
 <br/>
 Please visit <%=link_to 'this link', import_histories_url %> to see the individual import histories.<br/>
 <br/>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(:version => 20110628041037) do
   end
 
   create_table "import_histories", :force => true do |t|
-    t.integer  "survey_id",          :limit => 255
+    t.integer  "survey_id"
     t.string   "survey_response_id"
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
email uses count instead of select{}.length, removed notify_email from settings edit page
