### PR TITLE
Story #60: Ability to map UserID & FormID of a survey into Salesforce for User Form submission reporting

### DIFF
--- a/app/models/epi_surveyor/survey_response.rb
+++ b/app/models/epi_surveyor/survey_response.rb
@@ -77,6 +77,9 @@ module EpiSurveyor
       object_mapping.field_mappings.each do |field_mapping|
         sf_object[field_mapping.field_name] = value_for(field_mapping)
       end
+      sf_object_fields = sf_object.salesforce_fields.collect(&:name)
+      sf_object[APP_CONSTANTS['SALES_FORCE_FIELDS']['FORM_ID']] = survey.id if sf_object_fields.include?(APP_CONSTANTS['SALES_FORCE_FIELDS']['FORM_ID'])
+      sf_object[APP_CONSTANTS['SALES_FORCE_FIELDS']['USER_ID']] = self[APP_CONSTANTS['SURVEY_FORM_FIELDS']['USER_ID']]  if sf_object_fields.include?(APP_CONSTANTS['SALES_FORCE_FIELDS']['USER_ID'])
       sf_object
     end
     

--- a/config/app_constants.yml
+++ b/config/app_constants.yml
@@ -1,0 +1,5 @@
+SALES_FORCE_FIELDS:
+  FORM_ID: 'Form_ID__c'
+  USER_ID: 'User_ID__c'
+SURVEY_FORM_FIELDS:
+  USER_ID: 'UserId'

--- a/config/initializers/load_config.rb
+++ b/config/initializers/load_config.rb
@@ -1,0 +1,1 @@
+APP_CONSTANTS = YAML.load_file("#{Rails.root}/config/app_constants.yml")


### PR DESCRIPTION
assigning user_id & form_id from survey to salesforce object during sync. this will happen only if salesforce objects contain these fields. introduced app_constants to add app specific global constants in a yml file.
