### PR TITLE
Mapping Status| Added mapping_status to survey.

### DIFF
--- a/app/controllers/field_mappings_controller.rb
+++ b/app/controllers/field_mappings_controller.rb
@@ -5,6 +5,7 @@ class FieldMappingsController < AuthenticatedController
     @object_mapping.build_unmapped_field_mappings
     @questions = @object_mapping.survey.questions
     @questions_for_select = @questions.map {|question| [question.name, question.name]}
+    @unmapped_questions = @object_mapping.survey.unmapped_questions.collect(&:name)
     @salesforce_objects = Salesforce::Base.where(:enabled => true)
     add_crumb 'Surveys', surveys_path
     add_crumb 'Mappings', survey_mappings_path(@object_mapping.survey_id)

--- a/app/controllers/object_mappings_controller.rb
+++ b/app/controllers/object_mappings_controller.rb
@@ -29,6 +29,7 @@ class ObjectMappingsController < AuthenticatedController
   def update
     @object_mapping = ObjectMapping.find(params[:id])
     if @object_mapping.update_attributes(sanitized_params)
+      @object_mapping.survey.update_mapping_status
       flash[:notice] = "Successfully saved the mappings."
     else
       flash[:error] = "The mapping was not saved. Please check log file for more."

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -76,6 +76,13 @@ class SurveysController < AuthenticatedController
     add_crumb "Search results for: #{params[:query]}"
     render :index
   end
+
+  def update_mapping_status
+    survey = EpiSurveyor::Survey.find params[:id]
+    survey.update_attributes!(:mapping_status => params[:mapping_status])
+    flash[:notice] = "Mapping status updated"
+    redirect_to survey_mappings_path(survey)
+  end
   
   private
   def errors_count import_histories

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,23 +1,7 @@
 class SurveysController < AuthenticatedController
   
   def index
-    start_date=params[:start_date]
-    end_date=params[:end_date]
-    start_date=nil if start_date.nil? or start_date.empty?
-    end_date=nil if end_date.nil? or end_date.empty?
-    starts_with = params[:start_with]
-    starts_with = nil if starts_with.nil? or starts_with.empty?
-
-    if !start_date.nil? and !end_date.nil?
-      end_date = end_date.to_time.advance(:days => 1).to_date
-      @surveys = EpiSurveyor::Survey.ordered.modified_between(start_date, end_date).page(params[:page])
-    else
-      if !starts_with.nil?
-        @surveys = EpiSurveyor::Survey.ordered.starting_with(starts_with).page(params[:page])
-      else
-        @surveys = EpiSurveyor::Survey.ordered.page(params[:page])
-      end
-    end
+    @surveys = EpiSurveyor::Survey.ordered.having_mapping_status(params[:mapping_status]).starting_with(params[:start_with]).modified_between(params[:start_date], params[:end_date]).page(params[:page])
     add_crumb 'Surveys'
   end
   
@@ -103,6 +87,6 @@ class SurveysController < AuthenticatedController
     end
     
   end
-  
+
 
 end

--- a/app/models/epi_surveyor/survey.rb
+++ b/app/models/epi_surveyor/survey.rb
@@ -15,9 +15,11 @@ module EpiSurveyor
 
     scope :page, lambda { |page| paginate(:page => page) }
 
-    scope :modified_between, lambda { |start_date, end_date| where("surveys.mapping_last_modified_at between ? AND ?", start_date, end_date)}
+    scope :modified_between, lambda { |start_date, end_date| where("surveys.mapping_last_modified_at between ? AND ?", start_date, (end_date.to_date + 1.day)) if start_date.present? && end_date.present? }
 
-    scope :starting_with, lambda { |starting_char| where("UPPER(surveys.name) like ?", starting_char + '%') }
+    scope :starting_with, lambda { |starting_char| where("UPPER(surveys.name) like ?", starting_char + '%') if starting_char.present? }
+
+    scope :having_mapping_status, lambda { |requested_status| where("surveys.mapping_status = ?", requested_status) if requested_status.present? }
 
     module MAPPING_STATUS
       MAPPED = 'Mapped'

--- a/app/views/field_mappings/new.html.erb
+++ b/app/views/field_mappings/new.html.erb
@@ -81,6 +81,10 @@
 
 <%= render :partial => 'help' %>
 
+<div class="unmapped_fields">
+  <b>Unmapped Questions:</b> <%= select_tag("unmapped_questions", options_for_select(@unmapped_questions)) %>
+</div>
+
 <%= form_for @object_mapping do |object_mapping_form| %>
 	<div class="field_mapping_form">
 		<div class="field_mappings">

--- a/app/views/mappings/index.html.erb
+++ b/app/views/mappings/index.html.erb
@@ -12,6 +12,14 @@
 
 <%= render :partial => 'edit_links' %>
 
+<div class="mapping_details">
+  <%= form_tag update_mapping_status_survey_path(@survey), :method => :post do %>
+    <b>Mapping Status:</b> <span class="<%= @survey.mapping_status.underscore %>"><%= @survey.mapping_status %></span> |
+    <b>Update Status:</b> <%= select_tag("mapping_status", options_for_select(EpiSurveyor::Survey::MAPPING_STATUS::ALL, EpiSurveyor::Survey::MAPPING_STATUS::MAPPED)) %>
+    <%= submit_tag 'Update' %>
+  <% end %>
+</div>
+
 <ol class="object_mappings">
 <% @survey.object_mappings.each do |object_mapping|%>
 	<li class="object_mapping">

--- a/app/views/mappings/index.html.erb
+++ b/app/views/mappings/index.html.erb
@@ -14,6 +14,7 @@
 
 <div class="mapping_details">
   <%= form_tag update_mapping_status_survey_path(@survey), :method => :post do %>
+    <b>Unmapped Questions:</b> <%= select_tag("unmapped_questions", options_for_select(@survey.unmapped_questions.collect(&:name))) %> |
     <b>Mapping Status:</b> <span class="<%= @survey.mapping_status.underscore %>"><%= @survey.mapping_status %></span> |
     <b>Update Status:</b> <%= select_tag("mapping_status", options_for_select(EpiSurveyor::Survey::MAPPING_STATUS::ALL, EpiSurveyor::Survey::MAPPING_STATUS::MAPPED)) %>
     <%= submit_tag 'Update' %>

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -63,11 +63,12 @@
 			<div class="survey">
 				<div class="survey_name">
 					<%= check_box_tag 'survey_ids[]', survey.id %>
-					<span><%= survey.name %></span> | 
-					<%= "Imported #{distance_of_time_in_words(Time.now, survey.last_imported_at)} ago" if survey.last_imported_at%> | 
+					<span><%= survey.name %></span> |
+					<%= "Imported #{distance_of_time_in_words(Time.now, survey.last_imported_at)} ago" if survey.last_imported_at%> |
 					<span class="survey_last_modified"><%= "Mapping changed #{distance_of_time_in_words(Time.now, survey.mapping_last_modified_at)} ago" if survey.mapping_last_modified_at%></span>
 				</div>
-				<div class="actions">					
+				<div class="actions">
+          <span class="<%= survey.mapping_status.underscore %>"><%= survey.mapping_status %></span>|
 					<%= link_to 'Mappings', survey_mappings_path(survey.id) %> |
 					<%= link_to 'History', survey_import_histories_path(survey.id) %> |
 					<%= link_to 'Questions', survey_questions_path(survey.id) %> |

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -30,6 +30,8 @@
 	<td>Mapping Last modified date:</td>
 	<td><%= text_field_tag("start_date") %></td>
 	<td><%= text_field_tag("end_date") %></td>
+  <td>Mapping status:</td>
+  <td><%= select_tag(:mapping_status, options_for_select([['Any','']] + EpiSurveyor::Survey::MAPPING_STATUS::ALL, params[:mapping_status])) %></td>
 	<td><%= submit_tag("Filter") %></td>
 </tr><tr>
 		<td></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Camfed::Application.routes.draw do
     member do
       get 'edit'
       put 'update'
+      post 'update_mapping_status'
     end
     
     resources :import_histories do

--- a/db/migrate/20130114124504_add_mapping_status_to_surveys.rb
+++ b/db/migrate/20130114124504_add_mapping_status_to_surveys.rb
@@ -1,0 +1,15 @@
+class AddMappingStatusToSurveys < ActiveRecord::Migration
+  def self.up
+    add_column :surveys, :mapping_status, :string, :default => ''
+
+    EpiSurveyor::Survey.all.each do |survey|
+      survey.update_mapping_status
+    end
+
+  end
+
+  def self.down
+    remove_column :surveys, :mapping_status
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121102085123) do
+ActiveRecord::Schema.define(:version => 20130114124504) do
 
   create_table "add_default_value_to_field_mapppings", :force => true do |t|
     t.datetime "created_at"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(:version => 20121102085123) do
     t.datetime "updated_at"
     t.string   "notification_email"
     t.datetime "mapping_last_modified_at"
+    t.string   "mapping_status",           :default => ""
   end
 
   create_table "sync_errors", :force => true do |t|

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -410,3 +410,23 @@ span.survey_last_modified{
   height: 25px;
   text-indent: -9999px;
 }
+
+div.mapping_details{
+  padding-top: 15px;
+}
+
+div.unmapped_fields{
+    padding-top: 15px;
+}
+
+span.unmapped{
+  color: red;
+}
+
+span.mapped{
+  color: green;
+}
+
+span.partial{
+  color: blue;
+}

--- a/spec/controllers/field_mappings_controller_spec.rb
+++ b/spec/controllers/field_mappings_controller_spec.rb
@@ -14,6 +14,7 @@ describe FieldMappingsController do
     it 'should populate object mapping and questions' do
       ObjectMapping.should_receive(:find).with(2).and_return object_mapping
       object_mapping.should_receive :build_unmapped_field_mappings
+      survey.should_receive(:unmapped_questions).and_return [question]
 
       get :new, :object_mapping_id => 2
 
@@ -21,6 +22,7 @@ describe FieldMappingsController do
       assigns[:object_mapping].should == object_mapping
       assigns[:questions].should == [question]
       assigns[:questions_for_select].should == [['name', 'name']]
+      assigns[:unmapped_questions].should == ['name']
     end
   end
 

--- a/spec/controllers/object_mappings_controller_spec.rb
+++ b/spec/controllers/object_mappings_controller_spec.rb
@@ -58,8 +58,11 @@ describe ObjectMappingsController do
                                       }
                                     }
                 }
-
+      survey = EpiSurveyor::Survey.new(:id => 1)
+      EpiSurveyor::Survey.stub(:find).with(1, anything).and_return(survey)
+      survey.should_receive(:update_mapping_status)
       mapping = ObjectMapping.create(:survey_id => 1, :salesforce_object_name => 'AnObject')
+
       put :update, :id => mapping.id, :object_mapping => params[:object_mapping]
       mapping.reload
       mapping.field_mappings.first.field_name.should == 'a_field'

--- a/spec/controllers/surveys_controller_spec.rb
+++ b/spec/controllers/surveys_controller_spec.rb
@@ -115,4 +115,14 @@ describe SurveysController do
       assigns[:surveys].should == []
     end
   end
+
+  describe 'update_mapping_status' do
+    it 'should update mapping_status' do
+      survey = EpiSurveyor::Survey.create(:id => 1)
+      post 'update_mapping_status', :id => 1, :mapping_status => 'Mapped'
+      survey.reload
+      survey.mapping_status.should == 'Mapped'
+      response.should redirect_to survey_mappings_path(survey)
+    end
+  end
 end

--- a/spec/controllers/surveys_controller_spec.rb
+++ b/spec/controllers/surveys_controller_spec.rb
@@ -7,9 +7,9 @@ describe SurveysController do
   end
   
   describe "GET 'index'" do
-    it "should get the first page of all surveys if no page attribute is specified" do
+    it "should get the first page of all surveys if no filter attribute is specified" do
       surveys = []
-      EpiSurveyor::Survey.stub_chain(:ordered, :page).with(nil).and_return(surveys)
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status, :starting_with, :modified_between, :page).with(nil).and_return(surveys)
       get 'index'      
       response.should be_success
       assigns[:surveys].should == surveys
@@ -19,18 +19,18 @@ describe SurveysController do
       @relation = mock(ActiveRecord::Relation)
       surveys = []
       start_date = "2011/07/01"
-      end_date = "2011/07/15".to_time.advance(:days => 1).to_date
-      EpiSurveyor::Survey.stub_chain(:ordered, :modified_between).with(start_date, end_date).and_return(@relation)
+      end_date = "2011/07/15"
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status, :starting_with, :modified_between).with(start_date, end_date).and_return(@relation)
       @relation.should_receive(:page).with(nil).and_return(surveys)
-      get 'index', :start_date => '2011/07/01', :end_date => '2011/07/15'     
+      get 'index', :start_date => '2011/07/01', :end_date => '2011/07/15', :mapping_status => nil
       response.should be_success
       assigns[:surveys].should == surveys
     end
     
     it "should get first page of all surveys if only the start date is specified for the mapping last modified date filter" do
       surveys = []
-      EpiSurveyor::Survey.stub_chain(:ordered, :page).with(nil).and_return(surveys)
-      get 'index', :start_date => '2011/07/01', :end_date => ""    
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status, :starting_with, :modified_between, :page).with(nil).and_return(surveys)
+      get 'index', :start_date => '2011/07/01', :end_date => "", :mapping_status => nil
       response.should be_success
       assigns[:surveys].should == surveys
     end
@@ -38,7 +38,7 @@ describe SurveysController do
     it "should get the appropriate page of all surveys if page attribute is specified" do
       @page = 2
       surveys = []
-      EpiSurveyor::Survey.stub_chain(:ordered, :page).with(@page).and_return(surveys)
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status, :starting_with, :modified_between, :page).with(@page).and_return(surveys)
       get 'index', :page => 2
       response.should be_success
       assigns[:surveys].should == surveys
@@ -47,9 +47,19 @@ describe SurveysController do
     it "should get the first page of surveys starting with the specified alphabet" do
       @relation = mock(ActiveRecord::Relation)
       surveys = []
-      EpiSurveyor::Survey.stub_chain(:ordered, :starting_with).with('A').and_return(@relation)
-      @relation.should_receive(:page).with(nil).and_return(surveys)
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status, :starting_with).with('A').and_return(@relation)
+      @relation.stub_chain(:modified_between, :page).with(nil).and_return(surveys)
       get 'index', :start_with => 'A'
+      response.should be_success
+      assigns[:surveys].should == surveys
+    end
+
+    it "should get the first page of surveys starting with the specified mapping_status" do
+      @relation = mock(ActiveRecord::Relation)
+      surveys = []
+      EpiSurveyor::Survey.stub_chain(:ordered, :having_mapping_status).with(EpiSurveyor::Survey::MAPPING_STATUS::MAPPED).and_return(@relation)
+      @relation.stub_chain(:starting_with, :modified_between, :page).with(nil).and_return(surveys)
+      get 'index', :start_date => nil, :end_date => nil, :mapping_status => EpiSurveyor::Survey::MAPPING_STATUS::MAPPED
       response.should be_success
       assigns[:surveys].should == surveys
     end

--- a/spec/models/epi_surveyor/survey_spec.rb
+++ b/spec/models/epi_surveyor/survey_spec.rb
@@ -305,5 +305,79 @@ describe EpiSurveyor::Survey do
       survey.mapping_status.should == EpiSurveyor::Survey::MAPPING_STATUS::MAPPED
     end
   end
-  
+
+  describe "having_mapping_status" do
+    before :each do
+      @survey1 = EpiSurveyor::Survey.create(:mapping_status => EpiSurveyor::Survey::MAPPING_STATUS::MAPPED)
+      @survey2 = EpiSurveyor::Survey.create(:mapping_status => EpiSurveyor::Survey::MAPPING_STATUS::UNMAPPED)
+    end
+
+    it "should return all records if having_mapping_status is scoped but no mapping_status is requested" do
+      surveys = EpiSurveyor::Survey.having_mapping_status(nil)
+      surveys.size.should == 2
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_true
+    end
+
+    it "should return records with requested mapping_status" do
+      surveys = EpiSurveyor::Survey.having_mapping_status(EpiSurveyor::Survey::MAPPING_STATUS::MAPPED)
+      surveys.size.should == 1
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_false
+    end
+  end
+
+  describe "modified_between" do
+    before :each do
+      @survey1 = EpiSurveyor::Survey.create
+      @survey2 = EpiSurveyor::Survey.create
+      @survey1.update_attribute(:mapping_last_modified_at, Time.now - 2.days)
+      @survey2.update_attribute(:mapping_last_modified_at, Time.now - 1.days)
+    end
+
+    it "should return all records if modified_between is scoped but no start_date, end_date is requested" do
+      surveys = EpiSurveyor::Survey.modified_between(nil,'')
+      surveys.size.should == 2
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_true
+    end
+
+    it "should return all records if modified_between is scoped and start_date is provided but no end_date is requested" do
+      surveys = EpiSurveyor::Survey.modified_between(Date.today - 2.days, nil)
+      surveys.size.should == 2
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_true
+    end
+
+    it "should return records within requested dates" do
+      surveys = EpiSurveyor::Survey.modified_between(Date.today - 3.days, Date.today - 2.days)
+      surveys.size.should == 1
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_false
+    end
+  end
+
+  describe "starting_with" do
+    before :each do
+      @survey1 = EpiSurveyor::Survey.create
+      @survey2 = EpiSurveyor::Survey.create
+      @survey1.update_attribute(:name, 'Abc')
+      @survey2.update_attribute(:name, 'Def')
+    end
+
+    it "should return all records if starting_with is scoped but start_with is requested" do
+      surveys = EpiSurveyor::Survey.starting_with(nil)
+      surveys.size.should == 2
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_true
+    end
+
+    it "should return records with requested start_with" do
+      surveys = EpiSurveyor::Survey.starting_with('A')
+      surveys.size.should == 1
+      surveys.include?(@survey1).should be_true
+      surveys.include?(@survey2).should be_false
+    end
+  end
+
 end


### PR DESCRIPTION
Added mapping_status to survey. Determined mapping status of exisitng surveys. Also on each mapping update, system will determine if the status needs to be changed. This will happen only when the status is not 'Mapped'. Updated views to display mapping status on surveys & surveys>mapping screens. Added list of questions not yet mapped to the mapping screen. On the surveys>mappings screen user can update mapping status
